### PR TITLE
Update ocr_v2.py

### DIFF
--- a/ocr_v2.py
+++ b/ocr_v2.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # import the necessary packages
 from PIL import Image
 import pytesseract


### PR DESCRIPTION
Below fix resolves an issue :
"SyntaxError: Non-ASCII character '\xe2' in file" while running ocr_v2.py

Fix Reference :
https://stackoverflow.com/questions/21639275/python-syntaxerror-non-ascii-character-xe2-in-file